### PR TITLE
Add gulp-dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Stagehand](https://github.com/google/stagehand) - A project scaffolding generator, inspired by tools like Web Starter Kit and Yeoman.
 * [Crossdart](http://crossdart.info) - Cross-referenced source code of the packages from Pub.
 * [Crossdart Github Chrome Extension](https://chrome.google.com/webstore/detail/crossdart-chrome-extensio/jmdjoliiaibifkklhipgmnciiealomhd) - Adds "Go to declaration" and "Find Usages" functionality to your Dart projects on Github (both in tree views and pull requests).
+* [gulp-dart](https://github.com/agudulin/gulp-dart) - A gulp plugin for compiling Dart code to JavaScript using dart2js.
 
 ## Tutorials
 


### PR DESCRIPTION
A gulp plugin for compiling Dart to JS. Very useful if you are using Gulp as build system. It is published on NPM (https://www.npmjs.com/package/gulp-dart).