### PR TITLE
add Module Linker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Atom Plugin](https://atom.io/packages/atom-dart) - Dart support for Atom.
 * [DartPad](https://dartpad.dartlang.org/) - Online lightweight editor.
 * [Dart Code](https://marketplace.visualstudio.com/items?itemName=DanTup.dart-code) - Dart support for Visual Studio Code.
+* [Module Linker](http://fiatjaf.alhur.es/module-linker/#/dart) - Chrome Extension that adds direct links to module import statements on GitHub.
 
 ## Everything Else
 


### PR DESCRIPTION
[Module Linker](http://fiatjaf.alhur.es/module-linker/#/dart) is a [Chrome Extension](https://chrome.google.com/webstore/detail/module-linker/dglofghjinifeolcpjfjmfdnnbaanggn) that turns `import` and `part` declarations into actual `<a href="...">` links to the local file, external library repository or site, or standard library documentation of whatever is being imported.

![](https://raw.githubusercontent.com/fiatjaf/module-linker/gh-pages/screenshot/dart-screencast.gif)

For all Dart people who spend some time reading and browsing source code on GitHub, this Chrome Extension makes things easier and more pleasant.