### PR TITLE
Added json to dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Crossdart Github Chrome Extension](https://chrome.google.com/webstore/detail/crossdart-chrome-extensio/jmdjoliiaibifkklhipgmnciiealomhd) - Adds "Go to declaration" and "Find Usages" functionality to your Dart projects on Github (both in tree views and pull requests).
 * [gulp-dart](https://github.com/agudulin/gulp-dart) - A gulp plugin for compiling Dart code to JavaScript using dart2js.
 * [dev_compiler](https://github.com/dart-lang/dev_compiler) - Dart to JavaScript compiler designed to create idiomatic, readable JavaScript output.
+* [json2dart](https://javiercbk.github.io/json_to_dart) - Given a json, it generates the dart classes to parse and generate json with given structure.
 
 ## Tutorials
 


### PR DESCRIPTION
Added a tool that I've created to generate that, given a JSON, generates the dart classes that generate and parse the structure provided.

I've added the link to the github page because that is the useful part, but the project URL is [this one](https://github.com/javiercbk/json_to_dart).

This [reddit link](https://www.reddit.com/r/dartlang/comments/8e6wil/json_to_dart/) shows that some developers were quite happy discovering my library, so I think it is useful to list it in the awesome list.