### PR TITLE
Update Angular DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 
 ## Dependency Injection
 
-* [DI](https://github.com/angular/di.dart) - Dependency Injection framework by Angular
+* [Angular DI](https://webdev.dartlang.org/angular/guide/dependency-injection) - Dependency Injection framework by Angular
 * [Dependencies](https://github.com/marcguilera/dependencies.dart) - A simple and modular dependency injection system which doesn't use mirrors.
+* [package: inject](https://github.com/google/inject.dart) - Compile-time dependency injection for Dart and Flutter
 
 ## Parsers
 


### PR DESCRIPTION
the repository referred by DI on README.md was obsolete, now it's archived. 
I replaced it with official documentation of Angular DI on Angular Dart website.
And I add another package of dependency injection for Dart and Flutter.