### PR TITLE
Add json_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [dev_compiler](https://github.com/dart-lang/dev_compiler) - Dart to JavaScript compiler designed to create idiomatic, readable JavaScript output.
 * [json2dart](https://javiercbk.github.io/json_to_dart) - Given a json, it generates the dart classes to parse and generate json with given structure.
 * [webdev_proxy](https://github.com/Workiva/webdev_proxy) - A proxy wrapper around [webdev](https://github.com/dart-lang/webdev) which adds support for rerouting 404s to the index, allowing for HTML push-based routing while running locally.
+* [json_api](https://pub.dev/packages/json_api) - A [JSON:API](https://jsonapi.org/) Client for Flutter, Web and VM.
 
 ## Tutorials
 


### PR DESCRIPTION
[JSON:API](https://jsonapi.org/) is a specification for building APIs in JSON.

This package consists of several libraries:

- The Client to make requests to JSON:API servers
- The Server which is still under development
- The Document model for resources, relationships, identifiers, etc
- The Query to build and parse the query parameters (pagination, sorting, etc)
- The URL Design to build and match URLs for resources, collections, and relationships