### PR TITLE
Added Machine learning section along with m2cgen to bring ML to Dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [json2dart](https://javiercbk.github.io/json_to_dart) - Given a json, it generates the dart classes to parse and generate json with given structure.
 * [webdev_proxy](https://github.com/Workiva/webdev_proxy) - A proxy wrapper around [webdev](https://github.com/dart-lang/webdev) which adds support for rerouting 404s to the index, allowing for HTML push-based routing while running locally.
 
+## Machine Learning
+
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool that allows conversion of scikit-learn ML models into native code.
+
 ## Tutorials
 
 * [Hello Dart](http://code.makery.ch/library/hello-dart/) - A playful introduction to Dart.


### PR DESCRIPTION
https://github.com/BayesWitnesses/m2cgen

Found this repo a while back and contributed some code to allow the conversion of sklearn models into Dart code. This tool allows models to be converted with no dependencies. For those that develop in Dart and need to utilize a simpler model, this tool will do the trick.