### PR TITLE
Add es_compression to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Archive](https://pub.dartlang.org/packages/archive) - A library to encode and decode various archive and compression formats.
 * [built_collection](https://github.com/google/built_collection.dart) - Immutable collections via the builder pattern. 
 * [built_value](https://github.com/google/built_value.dart) - Immutable value types, enum classes, and serialization.
+* [es_compression](https://pub.dev/packages/es_compression) - Compression framework providing FFI implementations for Brotli, Lz4, Zstd with ready-to-use prebuilt binaries for Win/Linux/Mac.
 * [Frappe](https://pub.dartlang.org/packages/frappe) - A functional reactive programming library for Dart. Frappé extends the functionality of Dart's streams, and introduces new concepts like properties/signals.
 * [Quiver](https://github.com/google/quiver-dart) - A set of utility libraries that makes using many libraries easier and more convenient, or adds additional functionality.
 * [route_hierarchical](https://github.com/angular/route.dart) - Route is a client routing library for Dart that helps make building single-page web apps.


### PR DESCRIPTION
Pub.dev: https://pub.dev/packages/es_compression
Github: https://github.com/instantiations/es_compression
Reason to include: Access to modern compression schemes...compression framework for extending with more ffi or non-ffi compression schemes.