### PR TITLE
Add m2cgen for transpiling ML models into Dart code

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [json2dart](https://javiercbk.github.io/json_to_dart) - Given a json, it generates the dart classes to parse and generate json with given structure.
 * [webdev_proxy](https://github.com/Workiva/webdev_proxy) - A proxy wrapper around [webdev](https://github.com/dart-lang/webdev) which adds support for rerouting 404s to the index, allowing for HTML push-based routing while running locally.
 * [Dart Code Metrics](https://github.com/dart-code-checker/dart-code-metrics) - Additional linter which reports code metrics, checks for anti-patterns and provides additional rules for Analyzer.
+* [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Dart code with zero dependencies.
 
 ## Tutorials
 


### PR DESCRIPTION
https://github.com/BayesWitnesses/m2cgen

Hey there!
This PR proposes adding the same project as in #80, but I think that `Tools` section of this list is more suitable here because `m2cgen` is **not written** in Dart but **generates** Dart code.

`m2cgen` can allow Dart developers to easily use classic ML models in their app without learning any new API.