### PR TITLE
Add dart_agent_core to new AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
   * [Algorithms](#algorithms)
   * [Testing](#testing)
   * [Unions](#unions)
+  * [AI](#ai)
 * [Tools](#tools)
 * [IDEs, Editors, and Plugins](#ides-editors-and-plugins)
 * [Tutorials](#tutorials)
@@ -143,6 +144,10 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 ## Unions
 
 * [Freezed](https://github.com/rrousselGit/freezed) - Code generation for immutable classes that has a simple syntax/API without compromising on the features.
+
+## AI
+
+* [dart_agent_core](https://github.com/memex-lab/dart_agent_core) - A mobile-first, local-first agentic loop library with tool use, state persistence, multi-turn memory, and context compression for Flutter apps. Connects to mainstream LLM providers without a backend.
 
 ## Crash monitoring
 


### PR DESCRIPTION
## Summary

- Add [dart_agent_core](https://github.com/memex-lab/dart_agent_core) — a mobile-first, local-first agentic loop library for Flutter apps
- Create a new **AI** section, as there is currently no category for AI/LLM libraries

## Why it should be included

The Dart/Flutter ecosystem currently lacks a native AI agent orchestration library. `dart_agent_core` fills this gap by implementing a full agentic loop with tool use, state persistence, multi-turn memory, skill system, and context compression — entirely in Dart, with no Python or Node.js backend required. It connects to mainstream LLM providers (OpenAI, Gemini, Claude, and any OpenAI-compatible API).

The library is actively maintained, well documented, and works with the latest Dart SDK.