### PR TITLE
Add FlutterTrends to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [Dart Code Metrics](https://github.com/dart-code-checker/dart-code-metrics) - Additional linter which reports code metrics, checks for anti-patterns and provides additional rules for Analyzer.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Dart code with zero dependencies.
 * [Lakos](https://pub.dev/packages/lakos) - Visualize internal library dependencies in Graphviz and detect dependency cycles.
+* [FlutterTrends](https://fluttertrends.dev/) - Daily download trends, rankings, and repository health for 20k+ Flutter packages on pub.dev.
 
 ## Multithreading
 


### PR DESCRIPTION
Adds [FlutterTrends.dev](https://fluttertrends.dev/) to **Tools**.

FlutterTrends tracks the pub.dev package ecosystem: daily download trends and rankings for 20,000+ packages, plus repository health (last commit, CI presence, contributor concentration, license) and a maintainer-responsiveness metric (median time to first reply on closed issues). Static HTML, no login, free to browse, refreshed daily.

Why it fits: it sits alongside Crossdart as a website for exploring the pub.dev ecosystem, giving developers signal a package's own pub.dev page can't (which package leads a category, who is actively shipping, how responsive the maintainer is).

Meets the criteria: actively maintained (daily scrape), useful function, well documented, current SDK. Format and casing follow CONTRIBUTING.md; entry added to the bottom of `## Tools`.