### PR TITLE
Add loam to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [json2dart](https://javiercbk.github.io/json_to_dart) - Given a json, it generates the dart classes to parse and generate json with given structure.
 * [webdev_proxy](https://github.com/Workiva/webdev_proxy) - A proxy wrapper around [webdev](https://github.com/dart-lang/webdev) which adds support for rerouting 404s to the index, allowing for HTML push-based routing while running locally.
 * [Dart Code Metrics](https://github.com/dart-code-checker/dart-code-metrics) - Additional linter which reports code metrics, checks for anti-patterns and provides additional rules for Analyzer.
+* [loam](https://github.com/silvio-l/loam) - Codebase intelligence CLI that finds unused public API, circular dependencies and complexity hotspots behind a baseline/ratchet CI gate.
 * [m2cgen](https://github.com/BayesWitnesses/m2cgen) - A CLI tool to transpile trained classic ML models into a native Dart code with zero dependencies.
 * [Lakos](https://pub.dev/packages/lakos) - Visualize internal library dependencies in Graphviz and detect dependency cycles.
 * [FlutterTrends](https://fluttertrends.dev/) - Daily download trends, rankings, and repository health for 20k+ Flutter packages on pub.dev.


### PR DESCRIPTION
Adds loam under Tools, alongside Dart Code Metrics / Lakos. Codebase-intelligence CLI for Dart & Flutter (unused public API, circular dependencies, complexity hotspots; baseline/ratchet CI gate).