### PR TITLE
Add excel_plus to Parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [xmlstream](https://pub.dartlang.org/packages/xml) - A streaming event-based XML Parser.
 * [YAML](https://pub.dartlang.org/packages/yaml) - A parser for YAML.
 * [Dart Tags](https://pub.dartlang.org/packages/dart_tags) - The library for parsing ID3 tags, written in pure Dart.
+* [excel_plus](https://pub.dev/packages/excel_plus) - Streaming reader and writer for Excel .xlsx spreadsheets, with legacy .xls parsing.
 
 
 ## Validation


### PR DESCRIPTION
Adding `excel_plus` to the Parsers section.

Package: https://pub.dev/packages/excel_plus
Repo: https://github.com/almasumdev/excel_plus

**Why it belongs here:** it sits alongside the existing XML, YAML and HTML entries as a pure parser for a document format. It reads and writes the Office Open XML `.xlsx` format with a streaming SAX reader and lazy per-sheet loading rather than building a full DOM, so memory stays flat on large workbooks, and it also parses the legacy binary `.xls` (BIFF8) format with a built-in decoder that adds no dependencies.

**Against the contribution criteria:**

- *Actively maintained* — released regularly, currently 2.13.0.
- *Performs a useful function* — reading and writing spreadsheets is not otherwise covered in this list.
- *Used by the community* — around 8.5k downloads a month.
- *Well documented* — 97.3% of the public API carries doc comments, plus a README with examples.
- *Works with the latest SDK* — 160/160 pub points, all six platforms including web via both dart2js and wasm.

The row follows the format guidelines: capitalised description ending with a period, no SDK name, a single added line with no trailing whitespace.
