### PR TITLE
Add csv_plus to Parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Please take a quick look at the [contribution guidelines](/CONTRIBUTING.md) firs
 * [XML](https://pub.dartlang.org/packages/xml) - A lightweight library for parsing, traversing, querying and building XML documents.
 * [xmlstream](https://pub.dartlang.org/packages/xml) - A streaming event-based XML Parser.
 * [YAML](https://pub.dartlang.org/packages/yaml) - A parser for YAML.
+* [csv_plus](https://pub.dev/packages/csv_plus) - Zero-dependency CSV and TSV parser with type inference, schemas and streaming.
 * [Dart Tags](https://pub.dartlang.org/packages/dart_tags) - The library for parsing ID3 tags, written in pure Dart.
 
 


### PR DESCRIPTION
Adding `csv_plus` to the Parsers section.

Package: https://pub.dev/packages/csv_plus
Repo: https://github.com/almasumdev/csv_plus
Docs: https://csv-plus.web.app

**Why it belongs here:** it sits alongside the existing XML, YAML and HTML entries as a parser for a text format, and CSV is not otherwise covered in the list. It handles RFC 4180 properly, including quoted fields containing the delimiter, embedded newlines and doubled quotes, and infers types with a guard so a value like `007` stays a string instead of silently becoming 7.

Beyond parsing there is a streaming decoder with backpressure for files larger than memory, per-column schemas for validation and coercion, a queryable table with filter, sort, aggregate and group, presets for TSV, pipe and Excel output, and `dart:convert` integration.

**Against the contribution criteria:**

- *Actively maintained* — currently 1.2.1, released today.
- *Performs a useful function* — CSV is missing from the list.
- *Used by the community* — around 4.4k downloads a month.
- *Well documented* — full API docs plus a guide site.
- *Works with the latest SDK* — 160/160 pub points, and zero dependencies, so nothing to conflict with.

The row follows the format guidelines: capitalised description ending with a period, no SDK name, a single added line with no trailing whitespace.
